### PR TITLE
Created instructions dialog for download page

### DIFF
--- a/src/components/download/download.js
+++ b/src/components/download/download.js
@@ -20,6 +20,15 @@ import '../download/loader.css';
 import SaveIcon from '@material-ui/icons/Save';
 import devSocLogo from '../../imageassets/DevSoc.png';
 import { GetApp } from '@material-ui/icons';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  useMediaQuery,
+  useTheme,
+} from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   '@global': {
@@ -237,6 +246,10 @@ export default function Download() {
 
   const [fix, setfix] = useState(0);
   const [load, setload] = useState(true);
+  const [instructionDialogOpen, setInstructionDialogOpen] = useState(true);
+
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   // const [count, setcount] = useState();
 
   async function call1() {
@@ -370,6 +383,50 @@ export default function Download() {
 
   return (
     <Fragment>
+      {/* instructions dialog */}
+      <Dialog
+        open={instructionDialogOpen}
+        onClose={() => setInstructionDialogOpen(false)}
+        aria-labelledby="responsive-dialog-title"
+      >
+        <DialogTitle
+          id="responsive-dialog-title"
+          style={{
+            color: '#ef4646',
+          }}
+        >
+          {'Instructions'}
+        </DialogTitle>
+        <DialogContent>
+          <ol type={'1'}>
+            <li>{'Press the download button on top'}</li>
+            <li>{'Print dialog would open, select save as PDF'}</li>
+            <li>
+              <b>{'Important: '}</b>
+              {
+                'select the "background graphics" option in the dialog so that you get the colours in the page'
+              }
+            </li>
+          </ol>
+          <DialogContentText>
+            <span style={{ margin: '1rem 0' }}>
+              {'This is due to platform limitations.'}
+            </span>
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            autoFocus
+            onClick={() => setInstructionDialogOpen(false)}
+            style={{
+              color: '#ef4646',
+            }}
+          >
+            Got It!
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <div className={classes.root} id="root">
         {/* <SendMessagePopup
           count={count}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR :rocket: fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run start`) was run locally and new changes were working correctly
- [x] Lint (`npm run linter`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What was the previous behavior?
No dialogue on download page open.

Fixes #
N/A


## What is the new behavior?
Dialog box opens up explaining save to pdf options to user as download page is opened.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A